### PR TITLE
Refactor and extend API to be more like the Retsly SDK spec

### DIFF
--- a/src/Retsly/AgentRequest.php
+++ b/src/Retsly/AgentRequest.php
@@ -1,0 +1,7 @@
+<?php namespace Retsly;
+
+class AgentRequest extends Request {
+  function __construct (Client $client, $query=[]) {
+    return parent::__construct($client, "get", $client->getURL("agent"), $query);
+  }
+}

--- a/src/Retsly/Client.php
+++ b/src/Retsly/Client.php
@@ -1,7 +1,5 @@
 <?php namespace Retsly;
 
-require_once(__DIR__.'/Request.php');
-
 class Client {
   const BASE_URL = "https://rets.io/api/v1";
 
@@ -9,7 +7,12 @@ class Client {
    * Retsly API client
    * @param string $token
    * @param string $vendor
+   * @return Retsly\Client
    */
+  static function create ($token, $vendor="test") {
+    return new Client($token, $vendor);
+  }
+
   function __construct ($token, $vendor="test") {
     $this->token = $token;
     $this->vendor = $vendor;
@@ -30,8 +33,7 @@ class Client {
    * @return \Retsly\Request
    */
   function listings ($query=[]) {
-    $url = $this->getURL("listing", $this->vendor);
-    return $this->getRequest("get", $url, $query);
+    return new ListingRequest($this, $query);
   }
 
   /**
@@ -40,8 +42,7 @@ class Client {
    * @return \Retsly\Request
    */
   function agents ($query=[]) {
-    $url = $this->getURL("agent", $this->vendor);
-    return $this->getRequest("get", $url, $query);
+    return new AgentRequest($this, $query);
   }
 
   /**
@@ -50,8 +51,7 @@ class Client {
    * @return \Retsly\Request
    */
   function offices ($query=[]) {
-    $url = $this->getURL("office", $this->vendor);
-    return $this->getRequest("get", $url, $query);
+    return new OfficeRequest($this, $query);
   }
 
   /**
@@ -60,8 +60,7 @@ class Client {
    * @return \Retsly\Request
    */
   function openHouses ($query=[]) {
-    $url = $this->getURL("openhouse", $this->vendor);
-    return $this->getRequest("get", $url, $query);
+    return new OpenHouseRequest($this, $query);
   }
 
   /**
@@ -72,11 +71,11 @@ class Client {
    * @return \Retsly\Request
    */
   function getRequest ($method, $url, $query) {
-    return new Request($method, $url, $query, $this->token);
+    return new Request($this, $method, $url, $query);
   }
 
-  private function getURL ($resource, $vendor, $id="") {
-    return self::BASE_URL . "/" . $resource . "/" . $vendor . "/" . $id;
+  function getURL ($resource) {
+    return self::BASE_URL . "/" . $resource . "/" . $this->vendor . "/";
   }
 
 }

--- a/src/Retsly/ListingRequest.php
+++ b/src/Retsly/ListingRequest.php
@@ -1,0 +1,7 @@
+<?php namespace Retsly;
+
+class ListingRequest extends Request {
+  function __construct (Client $client, $query=[]) {
+    return parent::__construct($client, "get", $client->getURL("listing"), $query);
+  }
+}

--- a/src/Retsly/OfficeRequest.php
+++ b/src/Retsly/OfficeRequest.php
@@ -1,0 +1,7 @@
+<?php namespace Retsly;
+
+class OfficeRequest extends Request {
+  function __construct (Client $client, $query=[]) {
+    return parent::__construct($client, "get", $client->getURL("office"), $query);
+  }
+}

--- a/src/Retsly/OpenHouseRequest.php
+++ b/src/Retsly/OpenHouseRequest.php
@@ -1,0 +1,7 @@
+<?php namespace Retsly;
+
+class OpenHouseRequest extends Request {
+  function __construct (Client $client, $query=[]) {
+    return parent::__construct($client, "get", $client->getURL("openhouse"), $query);
+  }
+}

--- a/src/Retsly/RetslyException.php
+++ b/src/Retsly/RetslyException.php
@@ -1,7 +1,3 @@
 <?php namespace Retsly;
 
-use Exception;
-
-class RetslyException extends Exception {
-
-}
+class RetslyException extends \Exception {}

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once(__DIR__."/../Retsly/Client.php");
+require_once(__DIR__."/../src/Retsly/Client.php");
 use Retsly\Request;
 use Retsly\Client;
 

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -5,6 +5,12 @@ use Retsly\Request;
 use Retsly\Client;
 
 class ClientTest extends PHPUnit_Framework_TestCase {
+  function testBuilder() {
+    $c = Client::create("feep");
+    $this->assertTrue($c instanceof Client);
+    $this->assertEquals("test", $c->vendor);
+  }
+
   function testConstructor() {
     $c = new Client("bogus");
     $this->assertInternalType("string", $c->token);
@@ -19,7 +25,7 @@ class ClientTest extends PHPUnit_Framework_TestCase {
 
   function testGetRequest() {
     $c = new Client("bogus");
-    $r = $c->getRequest("GET", "http://google.com/", []);
+    $r = $c->getRequest("get", "http://google.com/", []);
     $this->assertInstanceOf("Retsly\Request", $r);
   }
 }

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -4,29 +4,75 @@ require_once(__DIR__."/../src/Retsly/Request.php");
 use Retsly\Request;
 
 class RequestTest extends PHPUnit_Framework_TestCase {
+  function getClient() {
+    return $this
+      ->getMockBuilder("Retsly\Client")
+      ->setConstructorArgs(["foo"])
+      ->getMock();
+  }
+
+  function getRequest($query=[]) {
+    $c = $this->getClient();
+    return new Request($c, "get", "https://google.com/", $query);
+  }
+
   function testConstructor() {
-    $q = ["foo" => 42];
-    $r = new Request("GET", "http://google.com/", $q, "token");
-    $this->assertEquals("GET", $r->method);
-    $this->assertEquals("http://google.com/", $r->url);
+    $q = ["ok" => 12];
+    $r = $this->getRequest($q);
+    $this->assertEquals("get", $r->method);
+    $this->assertEquals("https://google.com/", $r->url);
     $this->assertEquals($q, $r->query);
-    $this->assertEquals("token", $r->token);
   }
 
   function testQuery() {
-    $r = new Request("GET", "http://google.com/", [], "token");
+    $r = $this->getRequest();
     $r->query(["limit" => 10]);
     $this->assertEquals(10, $r->query["limit"]);
   }
 
   function testWhere() {
-    $r = new Request("GET", "http://google.com/", [], "token");
-
+    $r = $this->getRequest();
     $r->where("baths", "gte", 1)
       ->where("baths < 6")
       ->where("bedrooms", 4);
 
     $this->assertEquals(["gte" => 1, "lt" => 6], $r->query["baths"]);
     $this->assertEquals(4, $r->query["bedrooms"]);
+  }
+
+  function testLimit() {
+    $r = $this->getRequest();
+    $r->limit(10);
+    $this->assertEquals($r->query["limit"], 10);
+  }
+
+  function testOffset() {
+    $r = $this->getRequest();
+    $r->offset(10);
+    $this->assertEquals($r->query["offset"], 10);
+  }
+
+  function testNextPage() {
+    $r = $this->getRequest();
+    $r->limit(10)
+      ->nextPage()
+      ->nextPage();
+    $this->assertEquals(20, $r->query["offset"]);
+  }
+
+  function testPrevPage() {
+    $r = $this->getRequest();
+    $r->limit(10)
+      ->offset(40)
+      ->prevPage();
+    $this->assertEquals(30, $r->query["offset"]);
+  }
+
+  function testPrevPageStopsAtZero() {
+    $r = $this->getRequest();
+    $r->limit(10)
+      ->offset(0)
+      ->prevPage();
+    $this->assertEquals(0, $r->query["offset"]);
   }
 }

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once(__DIR__."/../Retsly/Request.php");
+require_once(__DIR__."/../src/Retsly/Request.php");
 use Retsly\Request;
 
 class RequestTest extends PHPUnit_Framework_TestCase {

--- a/test/RetslyExceptionTest.php
+++ b/test/RetslyExceptionTest.php
@@ -1,0 +1,12 @@
+<?php
+
+require_once(__DIR__."/../src/Retsly/RetslyException.php");
+use Retsly\RetslyException;
+
+class RetslyExceptionTest extends PHPUnit_Framework_TestCase {
+  function testType () {
+    $e = new RetslyException();
+    $this->assertTrue($e instanceof RetslyException);
+    $this->assertTrue($e instanceof Exception);
+  }
+}


### PR DESCRIPTION
This PR just reorganizes some code and adds a few methods, mainly to `Retsly\Request`, to be more like our internal SDK spec.