### PR TITLE
Fix composer install command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 
 With [Composer](https://getcomposer.org/):
 
-    $ composer install retsly/php-sdk
+    $ composer require retsly/php-sdk
 
 ## Usage
 


### PR DESCRIPTION
### Fixed
- composer install command.

`composer install` is not a valid command. To properly install the package via composer, it must be done through `composer require`.